### PR TITLE
fix: removed redundant duplicate key from dbt_project.yml

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,8 +6,6 @@ config-version: 2
 
 analysis-paths:
   - analysis
-clean-targets:
-  - target
 data-paths:
   - data
 macro-paths:


### PR DESCRIPTION
Ключ `clean-targets` указан дважды в конфиге с разными значениями и, соответственно, значение первый ключа переопределяется вторым.